### PR TITLE
[Feat] Backtracking Complete N-Queen

### DIFF
--- a/src/main/kotlin/backtracking/NQueen.kt
+++ b/src/main/kotlin/backtracking/NQueen.kt
@@ -1,0 +1,31 @@
+package backtracking
+
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import kotlin.math.abs
+
+val table = IntArray(15)
+var count = 0
+val N by lazy { readln().toInt() }
+
+fun main() {
+    N
+    queen(0)
+    println(count)
+}
+
+fun queen(col: Int) {
+    if (N == col) count++
+    for (i in 0 until N) {
+        table[col] = i
+        if (promisingCheck(col)) queen(col + 1)
+    }
+}
+
+fun promisingCheck(col: Int): Boolean {
+    for (i in 0 until col) {
+        if (table[i] == table[col] || col - i == abs(table[col] - table[i]))
+            return false
+    }
+    return true
+}


### PR DESCRIPTION
## N-Queen ( 9663 번 )

### Key Point
- 이게 왜 Backtracking인지가 제일 의문이었습니다.
- 배열도 왜 전역으로 써야하는가? 이것도 의문이었습니다.
- 그림으로 이해했습니다.

### N=8
- 현재 상태가 마지막까지 돌았을 때입니다.
- 하지만 초기 Queen 함수는 재귀가 쌓여있어 (0,0) 즉 포문 첫번째 루프도 끝내지 않고 기다리고 있게 됩니다.
- 그렇게 (7,5)까지의 재귀가 호출되고 (7,7)에 체스를 둔 채로 로직을 끝내게 되고, 다시 6행에서부터 체스 위치를 바꾸며 다시 6행 ~ 7행까지 검사를 하면서 다시 찾고, 그게 끝나면 5행에서 5행 ~ 7행까지 다시 검사하는 로직을 수행하고 있었습니다.
- 코드는 C++ 코드 조금 참고했습니다 ^^
<img width="913" alt="스크린샷 2022-08-13 오후 7 20 33" src="https://user-images.githubusercontent.com/15981307/184479504-2bd0253d-bdea-4621-b226-113c257d2509.png">
 - 시간 복잡도 O(N*N)