### PR TITLE
Greedy 문제 풀이

### DIFF
--- a/src/main/kotlin/greedy/Cupholder.kt
+++ b/src/main/kotlin/greedy/Cupholder.kt
@@ -1,0 +1,9 @@
+package greedy
+
+
+val N = readln().toInt()
+var S = readln()
+fun main() {
+    S = S.replace("LL", "L")
+    if (S.length + 1 > N) print(N) else print(S.length + 1)
+}

--- a/src/main/kotlin/greedy/VillageHead.kt
+++ b/src/main/kotlin/greedy/VillageHead.kt
@@ -1,0 +1,16 @@
+package greedy
+
+
+fun main() {
+    val N = readln().toInt()
+    val array = readLine()?.split(' ')?.map { it.toInt() }?.sortedDescending()
+    var day = 2
+    var sum = 0
+    array?.forEach {
+        if (sum < it + day) {
+            sum = it + day
+        }
+        day++
+    }
+    println(sum)
+}


### PR DESCRIPTION
### 컵홀더 (2810번)
- 중점은 커플석이 몇개가 있는지이다.
- 커플석이 있을 때마다 못 앉게 되는 인원들이 생길 것이다.
- 따라서 LL을 L로 치환해서 그때의 길이 (커플석이 있을 때마다 못 앉는 사람들이 하나씩 증가, 반대로 생각하면 LL을 L로 바꾼 문자열의 길이를 체크하면 된다)을 측정
- N보다 크다면 N이 된다.
- +1로 해야 답이 나오는데, 커플석이 하나만 있을 때는 다 앉을 수 있기 때문이다.
- 시간 복잡도 O(N)
<img width="291" alt="스크린샷 2022-08-15 오후 3 46 11" src="https://user-images.githubusercontent.com/15981307/184588863-afb9a0f1-6a42-41de-8856-561090513f65.png">

### 이장님 초대 (9237번)
- N은 사용 안했습니다.
- 처음 심는 시간, 이장님은 다음날 초대니깐 초기 day=2로 시작,
- 정렬된 array를 돌며, day는 1씩 추가되면서 day랑 더 했을 때 가장 큰 max sum을 구함
- 그것이 답입니다.
- 시간 복잡도 O(N)
<img width="287" alt="스크린샷 2022-08-15 오후 3 56 11" src="https://user-images.githubusercontent.com/15981307/184589974-079f1e44-6d83-435e-80bb-c98f1a86dba4.png">
 