### PR TITLE
[Feat] SerialNumber Complete

### DIFF
--- a/src/main/kotlin/sort/SerialNumber.kt
+++ b/src/main/kotlin/sort/SerialNumber.kt
@@ -1,0 +1,11 @@
+package sort
+
+fun main() {
+    val N = readln().toInt()
+    val array = mutableListOf<String>()
+    repeat(N){
+        array.add(readln())
+    }
+    val comparator: Comparator<String> = compareBy<String> { it.length }.thenBy { it -> it.replace("[^0-9]".toRegex(), "").map { it.digitToInt() }.sum() }.thenBy { it }
+    println(array.sortedWith(comparator).joinToString("\n"))
+}


### PR DESCRIPTION
### 시리얼 번호 ( 1431번 )
- 기존 WordSort thenby만 수정하면 됐었습니다.
- 숫자 비교가 빡세서 정규식 사용하였습니다.
- 자릿수 비교를 위해 map으로 만든 후 sum을 사용하였습니다.
- 시간복잡도 : O(nlogn)
<img width="478" alt="스크린샷 2022-08-20 오후 4 48 28" src="https://user-images.githubusercontent.com/15981307/185734954-a89c2867-94ac-4a79-a394-55c0b85ac099.png">
