### PR TITLE
[Feat] NumberJump Problem Complete

### DIFF
--- a/src/main/kotlin/graph/NumberJump.kt
+++ b/src/main/kotlin/graph/NumberJump.kt
@@ -1,0 +1,33 @@
+package graph
+
+val intRangeX = intArrayOf(0, 0, 1, -1)
+val intRangeY = intArrayOf(1, -1, 0, 0)
+val ans = mutableSetOf<String>()
+val map = ArrayList<List<String>>()
+
+fun main() {
+    repeat(5) {
+        map.add(readln().split(" "))
+    }
+
+    repeat(5) { y ->
+        repeat(5) { x ->
+            searchSixDigits(1, map[y][x], Pair(y, x))
+        }
+    }
+    print(ans.size)
+}
+
+fun searchSixDigits(count: Int, str: String, point: Pair<Int, Int>) {
+    if (count == 6) {
+        ans.add(str)
+        return
+    }
+
+    for (i in 0 until 4) {
+        val dx = point.second + intRangeX[i]
+        val dy = point.first + intRangeY[i]
+        if (dx < 0 || dy < 0 || dx >= 5 || dy >= 5) continue
+        searchSixDigits(count + 1, str + map[dy][dx], Pair(dy, dx))
+    }
+}


### PR DESCRIPTION
## 숫자판 점프! (2210번)
### Key Point : 서치 알고리즘 잘 쓰기 ㅎ
- 임의의 한 점에서 만들 수 있는 경우가 있어야해서 전체 2중 포문 돌렸습니다.
- count를 최대치로 정해서 6개까지만 처리하게 했슴당!
- 더 좋은 방법이 있는진 모르겠네요 하하
- 시간복잡도 : O(1) 맵도 5x5 고정, 숫자판도 6개 고정이라 N Time이라고 쓰기가 애매하네요
<img width="471" alt="스크린샷 2022-10-24 오전 12 52 28" src="https://user-images.githubusercontent.com/15981307/197402212-617d2dd5-d523-42a9-9641-6c4ef24c1c34.png">
