### PR TITLE
[Feat] PresentExchange Problem Complete

### DIFF
--- a/src/main/kotlin/graph/PresentExchange.kt
+++ b/src/main/kotlin/graph/PresentExchange.kt
@@ -1,0 +1,61 @@
+package graph
+
+import java.io.BufferedWriter
+import java.io.OutputStreamWriter
+import java.lang.StringBuilder
+
+private data class Student(val num: Int, var target: IntArray, var count: Int = 0)
+
+fun main() {
+    val N = readln().toInt()
+    val listQueue = Array<Student>(N) {
+        Student(it + 1, IntArray(2))
+    }
+    val str = StringBuilder()
+    val bw = BufferedWriter(OutputStreamWriter(System.out))
+    val visit = BooleanArray(N + 1)
+    visit[0] = true
+    repeat(N) { index ->
+        val (first, second) = readln().split(" ").map { it.toInt() }
+        listQueue[index].target = intArrayOf(first, second)
+        listQueue[first - 1].count++
+        listQueue[second - 1].count++
+    }
+    var removeCount = 0
+    val data = listQueue.filter { it.count < 2 }.toMutableList()
+    while (data.isNotEmpty()) {
+        val front = data.removeFirst()
+        removeCount++
+        visit[front.num] = true
+        val (first, second) = front.target
+        listQueue[first - 1].count--
+        listQueue[second - 1].count--
+        if (listQueue[first - 1].count == 1) {
+            data.add(listQueue[first - 1])
+        }
+        if (listQueue[second - 1].count == 1) {
+            data.add(listQueue[second - 1])
+        }
+    }
+    str.append("${N - removeCount}\n")
+    visit.forEachIndexed { index, b ->
+        if (!b) {
+            str.append("${index} ")
+        }
+    }
+    bw.write(str.toString())
+    bw.close()
+}
+
+/*
+1, 2, 3,         4,     5
+2, 2, (1, 4), ,  (2, 3, 4)
+
+
+현재 번호, 준 선물, 받은 선물
+받은 선물.size < 2 일 때, 준 선물들 회수
+
+
+
+4(3, 5)
+ */


### PR DESCRIPTION
## 선물 교환
### Key Point : 메모리 초과, 시간 초과의 향연
- 메모리 초과, 시간초과 겁나게 뜨길래 https://www.acmicpc.net/board/view/89191 해당 링크 참고해서 LinkedList 쓰던거 다 바꿔줬습니다..
- 고냥 리스트로 처리..
- 2보다 작은 리스트들의 큐를 만든다. 걔네들이 주려는 학생들 선물도 없애야함
- while돌면서 count로 다른 학생이 받을 선물들 마이너스 처리시키고 그 친구들의 count가 2보다 작은 친구들은 큐에 새로 추가해줬습니다!!
- 로직은 한 참 전부터 그대로였는데 자료구조만 바꼈네요 ㅎ
- removeCount는 괜히 셌숩니당 filter 처리해도 됐긴했어유 
- 시간복잡도 : O(N^2)

<img width="534" alt="스크린샷 2023-01-25 오전 2 15 41" src="https://user-images.githubusercontent.com/15981307/214361947-4f2736c8-cb78-4987-a79c-f94e83685ccb.png">
