### PR TITLE
[Feat] RockGroup Problem Complete

### DIFF
--- a/src/main/kotlin/graph/RockGroup.kt
+++ b/src/main/kotlin/graph/RockGroup.kt
@@ -1,0 +1,39 @@
+package graph
+
+import java.util.LinkedList
+
+fun main() {
+    val (A, B, C) = readln().split(" ").map { it.toInt() }
+    var total = (A + B + C)
+    if (total % 3 != 0) {
+        println(0)
+        return
+    }
+    val visitArray = Array<IntArray>(total + 1) {
+        IntArray(total + 1)
+    }
+    val queue = LinkedList<Pair<Int, Int>>()
+    queue.offer(A to B)
+    visitArray[A][B] = 1
+    searchThreeCount(total, visitArray, queue)
+    println(visitArray[total / 3][total / 3])
+}
+
+fun searchThreeCount(total: Int, visitArray: Array<IntArray>, queue: LinkedList<Pair<Int, Int>>) {
+    while (queue.isNotEmpty()) {
+        val (A, B) = queue.poll()
+        val countList = listOf(A, B, total - (A + B))
+        for (i in 0 until 3) {
+            for (j in 0 until 3) {
+                if (countList[i] < countList[j]) {
+                    val temp1 = countList[i] * 2
+                    val temp2 = countList[j] - countList[i]
+                    if (visitArray[temp1][temp2] != 1) {
+                        visitArray[temp1][temp2] = 1
+                        queue.offer(temp1 to temp2)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 돌 그룹 풀이
### Key Point : 돌 두개만 계산하면 끝
- 날짜를 잘못봐서 이제 풀었네요 ㅜㅜ 미안합니당
- visit를 만들어서 total/3의 영역만 true면 끝
- C는 total - (A + B) 하면 되구
- 리스트 돌면서 모든 케이스를 다 index에 저장을 시켜버립니다.
- 이차원 배열은 혹시 몰라서( * 2를 하니깐...) total의 크기로 주었습니다.
- 3개의 모든 케이스를 서치해야해서 이중 포문 3번씩 돌렸는데 중복 되는 부분이 있겠네요.. 포문 하나로 할 수 있었을듯
- 그러고 visit 배열의 visitArray[total / 3][total / 3] 영역 출력하면 0인지 1인지 나올 것입니당.
- 살짝 인터넷 참고함,,
- 시간복잡도 : O(N^2)으로 추정..됨..?
<img width="958" alt="스크린샷 2023-02-12 오후 3 39 36" src="https://user-images.githubusercontent.com/15981307/218296943-42052d5a-c7d5-43e7-b4d7-7b863b7c9109.png">
