### PR TITLE
[FEAT] HighRiseBuilding Problem Complete

### DIFF
--- a/src/main/kotlin/math/HighRiseBuilding.kt
+++ b/src/main/kotlin/math/HighRiseBuilding.kt
@@ -1,0 +1,42 @@
+package math
+
+import java.math.BigDecimal
+
+fun main() {
+    val N = readln().toInt()
+    val list = readln().split(" ").map { it.toInt() }
+    var maxCount = 0
+    repeat(N) { currentIndex ->
+        var count = 0
+        var minLeftGradient = BigDecimal.valueOf(-Double.MAX_VALUE)
+        var minRightGradient = BigDecimal.valueOf(-Double.MAX_VALUE)
+        val currentX = list[currentIndex]
+        for (x in currentIndex + 1 until N) {
+            val value = BigDecimal.valueOf((list[x] - currentX) / ((x - currentIndex)).toDouble())
+            if (minRightGradient < value) {
+                minRightGradient = value
+                count++
+            }
+        }
+        for (x in currentIndex - 1 downTo 0) {
+            val value = BigDecimal.valueOf(-((currentX - list[x]) / ((currentIndex - x)).toDouble()))
+            if (minLeftGradient < value) {
+                minLeftGradient = value
+                count++
+            }
+        }
+        maxCount = maxCount.coerceAtLeast(count)
+    }
+    println(maxCount)
+}
+
+
+/*
+(y1, x1), (y2, x2)
+
+기울기
+
+|(x2-x1)/(y2-y1)|
+
+
+ */


### PR DESCRIPTION
## 고층빌딩
### Key Point : 수학, 기울기
- 기울기가 키포인트였습니다!
- Double로 풀면 부동소수점 오류나서 BigDecimal 썼습니당.
- 어떤 건물 기준으로 왼쪽인지 오른쪽인지에 따라서 기울기 부호를 바꿔야했습니당.
- 쉽게 생각하면 점으로 이동하면서 기울기를 기록해두고 이전 기울기 보다 더 큰 값이라면 중간에 다른 빌딩과 걸리지 않을테니 count를 늘려줄 수 있습니다.
- 하지만 가운데 기준으로 왼쪽 빌딩을 계산할 때는 기울기를 반대로 생각해야합니당.
- 기울기의 값이 작을수록 기울기가 더 높다고 생각해야합니당.
- 왼쪽 검사할 때는 음수 부호 붙였네용
- 시간 복잡도 : O(N^2)
<img width="783" alt="스크린샷 2023-02-27 오후 7 18 13" src="https://user-images.githubusercontent.com/15981307/221537089-74fa6af8-b811-4609-a599-c1fe0cd1ab02.png">
